### PR TITLE
Update README with macOS installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ Users receive the data in form of a CSV and a YAML file on their Desktop which c
 
 Installers for macOS and Windows can be found under [Releases](https://github.com/Leibniz-HBI/webhistopy/releases).
 
+If macOS prompts you that it can't scan the dmg for malware, you can open it anyway by clicking `Done` and opening `System Settings > Privacy and Security`, scrolling down and clicking the button `Open Anyway`. (It is available for a while after the last attempt to open it). This is not recommended for any software you do not trust!
+
 But please be aware that the software is experimental and will most likely be outdated without a recent update of the code and dependencies, which means, e.g., that it might misread the respective browser databases.
 
 Please be aware of known issues in [Issues](https://github.com/Leibniz-HBI/webhistopy/issues) and verify results before using the app for research purposes.


### PR DESCRIPTION
Added instructions for bypassing macOS malware scan warnings and cautioned about software being experimental.